### PR TITLE
fix:(script) remove berks dir recursively

### DIFF
--- a/.expeditor/upload_cookbooks.sh
+++ b/.expeditor/upload_cookbooks.sh
@@ -6,7 +6,7 @@ set -eou pipefail
 key_path=/tmp/key.pem
 
 function cleanup() {
-  rm -f "$key_path" berks-cookbooks
+  rm -rf "$key_path" berks-cookbooks
 }
 
 vault kv get -field afiune_private_key secret/chef-workstation/hosted-org > $key_path


### PR DESCRIPTION
Error message from the logs after execution:
```
... 
Uploading go-counter-cookbook [0.1.1]
Uploaded 1 cookbook.
rm: cannot remove 'berks-cookbooks': Is a directory
[2020-01-16 17:46:15 +0000] An error occurred executing `bash:.expeditor/upload_cookbooks.sh`
[2020-01-16 17:46:15 +0000] action bash:.expeditor/upload_cookbooks.sh complete (failed)
```

### Almost perfect!
![tenor-71456336](https://user-images.githubusercontent.com/5712253/72549668-5b626100-384e-11ea-9b20-a2fcb4e3913b.gif)

Signed-off-by: Salim Afiune <afiune@chef.io>
